### PR TITLE
Clean up or document unsafe code and panics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  pull_request: ~
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - run: sudo apt-get install -y --no-install-recommends libopenmpi-dev libpmix-dev
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo clippy --features=test-bins -- --deny warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,8 @@ serial_test = "3.3.1"
 
 [features]
 test-bins = ["dep:mpi", "dep:notify"]
+
+[lints.clippy]
+panic = "warn"
+unwrap_used = "warn"
+undocumented_unsafe_blocks = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ required-features = ["test-bins"]
 
 [dependencies]
 futures = "0.3.31"
-tokio = { version = "1", features = ["rt", "macros", "io-util"] }
+tokio = { version = "1", features = ["rt", "macros", "io-util", "process"] }
 kube = { version = "3", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.27", features = ["v1_35"] }
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,7 @@ test-bins = ["dep:mpi", "dep:notify"]
 panic = "warn"
 unwrap_used = "warn"
 undocumented_unsafe_blocks = "warn"
+
+[lints.rust]
 # lib is for internal use only, so we don't care about stability
 async_fn_in_trait = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ test-bins = ["dep:mpi", "dep:notify"]
 panic = "warn"
 unwrap_used = "warn"
 undocumented_unsafe_blocks = "warn"
+# lib is for internal use only, so we don't care about stability
+async_fn_in_trait = "allow"

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ set -euo pipefail
 
 dnf install -y rustup
 rustup-init -y --no-modify-path --profile minimal --default-toolchain stable
-rustup component add rustfmt
+rustup component add rustfmt clippy
 EOF
 
 RUN --mount=type=cache,target=/var/cache/libdnf5 \

--- a/src/bin/mock/client.rs
+++ b/src/bin/mock/client.rs
@@ -45,12 +45,12 @@ fn pmix() -> Result<(), Error> {
     assert!(pmix::is_initialized());
     let namespace = c.namespace().to_str().unwrap();
     assert!(!namespace.starts_with("singleton."));
-    let v = c.get_job(None, pmix::sys::PMIX_JOB_SIZE);
+    let v = c.get_job(None, pmix::sys::PMIX_JOB_SIZE)?;
     assert_eq!(pmix::sys::PMIX_UINT32 as u16, v.type_);
     // SAFETY: We have checked that the type is uint32 above
     assert_eq!(1, unsafe { v.data.uint32 });
 
-    let v = c.get_proc(None, pmix::sys::PMIX_LOCAL_RANK);
+    let v = c.get_proc(None, pmix::sys::PMIX_LOCAL_RANK)?;
     assert_eq!(pmix::sys::PMIX_UINT16 as u16, v.type_);
     // SAFETY: We have checked that the type is uint16 above
     assert_eq!(0, unsafe { v.data.uint16 });

--- a/src/bin/mock/client.rs
+++ b/src/bin/mock/client.rs
@@ -47,10 +47,12 @@ fn pmix() -> Result<(), Error> {
     assert!(!namespace.starts_with("singleton."));
     let v = c.get_job(None, pmix::sys::PMIX_JOB_SIZE);
     assert_eq!(pmix::sys::PMIX_UINT32 as u16, v.type_);
+    // SAFETY: We have checked that the type is uint32 above
     assert_eq!(1, unsafe { v.data.uint32 });
 
     let v = c.get_proc(None, pmix::sys::PMIX_LOCAL_RANK);
     assert_eq!(pmix::sys::PMIX_UINT16 as u16, v.type_);
-    assert_eq!(0, unsafe { v.data.rank });
+    // SAFETY: We have checked that the type is uint16 above
+    assert_eq!(0, unsafe { v.data.uint16 });
     Ok(())
 }

--- a/src/bin/mock/main.rs
+++ b/src/bin/mock/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used, clippy::panic)]
 use anyhow::Error;
 use clap::{Parser, Subcommand};
 

--- a/src/bin/mock/server.rs
+++ b/src/bin/mock/server.rs
@@ -54,7 +54,7 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
     )
     .await
     .unwrap();
-    peers.register(&fence.addr());
+    peers.register(&fence.addr()).unwrap();
 
     let peer_dir = tmpdir.join("peer-discovery-modex");
     fs::create_dir_all(&peer_dir).unwrap();
@@ -64,8 +64,9 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
         &peers,
         nprocs,
     )
-    .await;
-    peers.register(&modex.addr());
+    .await
+    .unwrap();
+    peers.register(&modex.addr()).unwrap();
     let s = pmix::server::Server::init(fence, modex).unwrap();
 
     let hostnames = peers.hostnames().collect::<Vec<_>>();

--- a/src/bin/mock/server.rs
+++ b/src/bin/mock/server.rs
@@ -52,7 +52,8 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
         net::SocketAddr::new(net::Ipv6Addr::LOCALHOST.into(), 0),
         &peers,
     )
-    .await;
+    .await
+    .unwrap();
     peers.register(&fence.addr());
 
     let peer_dir = tmpdir.join("peer-discovery-modex");

--- a/src/bin/mock/server.rs
+++ b/src/bin/mock/server.rs
@@ -30,7 +30,7 @@ fn spawn_client<D: peer::PeerDiscovery>(
     let mut cmd = Command::new(std::env::current_exe().unwrap());
     cmd.arg("client")
         .args(args)
-        .envs(&c.envs())
+        .envs(&c.envs().unwrap())
         .spawn()
         .unwrap()
 }
@@ -74,11 +74,11 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
     let hostnames = peers.hostnames().collect::<Vec<_>>();
     let hostnames = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();
     let namespace = &CString::new(namespace).unwrap();
-    let n = pmix::server::Namespace::register(&s, namespace, &hostnames, nprocs);
+    let n = pmix::server::Namespace::register(&s, namespace, &hostnames, nprocs)?;
     let clients = peers
         .local_ranks(nprocs)
         .map(|i| pmix::server::Client::register(&n, i))
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
 
     let ps = clients
         .iter()

--- a/src/bin/mock/server.rs
+++ b/src/bin/mock/server.rs
@@ -67,7 +67,9 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
     .await
     .unwrap();
     peers.register(&modex.addr()).unwrap();
-    let s = pmix::server::Server::init(fence, modex).unwrap();
+
+    let server_dir = tmpdir.join("server");
+    let s = pmix::server::Server::init(fence, modex, &server_dir).unwrap();
 
     let hostnames = peers.hostnames().collect::<Vec<_>>();
     let hostnames = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();

--- a/src/fence.rs
+++ b/src/fence.rs
@@ -26,8 +26,7 @@ impl<'a, D: PeerDiscovery> NetFence<'a, D> {
     }
 
     pub fn addr(&self) -> SocketAddr {
-        // We know we have bound a local socket, so this can be unwrapped.
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used, reason = "We know we have a socket bound")]
         self.listener.local_addr().unwrap()
     }
 
@@ -115,8 +114,8 @@ impl<'a, D: PeerDiscovery> NetFence<'a, D> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod test {
+    #![allow(clippy::unwrap_used)]
     use std::{collections::HashSet, net::Ipv4Addr};
 
     use super::*;

--- a/src/fence.rs
+++ b/src/fence.rs
@@ -66,7 +66,8 @@ impl<'a, D: PeerDiscovery> NetFence<'a, D> {
                 Err(e) => return Err(e),
             }
         };
-        s.write_all(data).await.map(|_| ())
+        s.write_all(data).await;
+        Ok(())
     }
 
     async fn submit_data(&self, procs: &[sys::pmix_proc_t], data: &[u8]) -> io::Result<Vec<u8>> {

--- a/src/fence.rs
+++ b/src/fence.rs
@@ -25,6 +25,8 @@ impl<'a, D: PeerDiscovery> NetFence<'a, D> {
     }
 
     pub fn addr(&self) -> SocketAddr {
+        // We know we have bound a local socket, so this can be unwrapped.
+        #[allow(clippy::unwrap_used)]
         self.listener.local_addr().unwrap()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(never_type)]
+
 use std::{error::Error, fmt, io};
 
 use clap::Parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ pub struct Cli {
     pub args: Vec<String>,
 }
 
-#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(never_type)]
-
 use std::{error::Error, fmt, io};
 
 use clap::Parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub struct Cli {
     pub args: Vec<String>,
 }
 
+#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,5 +33,11 @@ mod test {
         assert_eq!(cli.nproc, 2);
         assert_eq!(cli.command, "foo");
         assert_eq!(cli.args, ["bar", "--baz"]);
+
+        let cli =
+            Cli::try_parse_from(["pmi-k8s", "--nproc=2", "--", "foo", "bar", "--baz"]).unwrap();
+        assert_eq!(cli.nproc, 2);
+        assert_eq!(cli.command, "foo");
+        assert_eq!(cli.args, ["bar", "--baz"]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,19 @@
+use std::{error::Error, fmt, io};
+
 use clap::Parser;
 
 pub mod fence;
 pub mod modex;
 pub mod peer;
 pub mod pmix;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ModexError<E: Error + fmt::Debug> {
+    #[error("error in modex communication")]
+    Io(#[from] io::Error),
+    #[error("error in peer discovery")]
+    Peer(E),
+}
 
 #[derive(Parser, Debug)]
 pub struct Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use std::{net, pin::pin, process::Command};
+use tempdir::TempDir;
 
 use anyhow::Error;
 
@@ -35,7 +36,8 @@ async fn main() -> Result<(), Error> {
     let hostnames = peers.hostnames().collect::<Vec<_>>();
     let hostname_refs = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();
 
-    let s = pmix::server::Server::init(fence, modex).unwrap();
+    let tempdir = TempDir::new("pmi-k8s").unwrap();
+    let s = pmix::server::Server::init(fence, modex, tempdir.path()).unwrap();
     let ns = pmix::server::Namespace::register(&s, namespace, &hostname_refs, args.nproc);
     let clients = peers
         .local_ranks(args.nproc)

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Error> {
 
     let rcs = match select(rcs, run).await {
         Either::Left((rcs, _)) => rcs?,
-        Either::Right((err, _)) => err?,
+        Either::Right((Err(err), _)) => Err(err)?,
     };
 
     assert!(rcs.iter().all(|rc| rc.success()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,13 @@ async fn main() -> Result<(), Error> {
             .collect::<Result<Vec<_>, _>>()
     });
     let run = pin!(s.run());
-    let Either::Left((rcs, _)) = select(rcs, run).await else {
-        panic!("server stopped unexpectedly")
+    let rcs = match select(rcs, run).await {
+        Either::Left((Ok(rcs), _)) => rcs?,
+        Either::Left((Err(e), _)) => Err(e)?,
+        Either::Right((Err(e), _)) => Err(e)?,
     };
 
-    assert!(rcs??.iter().all(|rc| rc.success()));
+    assert!(rcs.iter().all(|rc| rc.success()));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ async fn main() -> Result<(), Error> {
         net::SocketAddr::new("0.0.0.0".parse().unwrap(), PORT),
         &peers,
     )
-    .await;
+    .await
+    .unwrap();
     let modex = NetModex::new(
         net::SocketAddr::new("0.0.0.0".parse().unwrap(), PORT + 1),
         &peers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,56 +13,47 @@ use pmi_k8s::{
     pmix,
 };
 
+const WILDCARD: net::IpAddr = net::IpAddr::V4(net::Ipv4Addr::new(0, 0, 0, 0));
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {
     let args = Cli::parse();
     let namespace = c"foo";
 
     let peers = KubernetesPeers::new().await?;
-    let fence = NetFence::new(
-        net::SocketAddr::new("0.0.0.0".parse().unwrap(), PORT),
-        &peers,
-    )
-    .await
-    .unwrap();
-    let modex = NetModex::new(
-        net::SocketAddr::new("0.0.0.0".parse().unwrap(), PORT + 1),
-        &peers,
-        args.nproc,
-    )
-    .await
-    .unwrap();
+    let fence = NetFence::new(net::SocketAddr::new(WILDCARD, PORT), &peers).await?;
+    let modex = NetModex::new(net::SocketAddr::new(WILDCARD, PORT + 1), &peers, args.nproc).await?;
 
     let hostnames = peers.hostnames().collect::<Vec<_>>();
     let hostname_refs = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();
 
-    let tempdir = TempDir::new("pmi-k8s").unwrap();
-    let s = pmix::server::Server::init(fence, modex, tempdir.path()).unwrap();
+    let tempdir = TempDir::new("pmi-k8s")?;
+    let s = pmix::server::Server::init(fence, modex, tempdir.path())?;
     let ns = pmix::server::Namespace::register(&s, namespace, &hostname_refs, args.nproc);
     let clients = peers
         .local_ranks(args.nproc)
-        .map(|i| pmix::server::Client::register(&ns, i as u32))
+        .map(|i| pmix::server::Client::register(&ns, i))
         .collect::<Vec<_>>();
 
     let ps = clients
         .iter()
         .map(|c| {
             let mut cmd = Command::new(&args.command);
-            cmd.envs(&c.envs()).args(&args.args).spawn().unwrap()
+            cmd.envs(&c.envs()).args(&args.args).spawn()
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
 
     let rcs = tokio::task::spawn_blocking(|| {
         ps.into_iter()
-            .map(|mut p| p.wait().unwrap())
-            .collect::<Vec<_>>()
+            .map(|mut p| p.wait())
+            .collect::<Result<Vec<_>, _>>()
     });
     let run = pin!(s.run());
     let Either::Left((rcs, _)) = select(rcs, run).await else {
         panic!("server stopped unexpectedly")
     };
 
-    assert!(rcs.unwrap().iter().all(|rc| rc.success()));
+    assert!(rcs??.iter().all(|rc| rc.success()));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use std::{net, pin::pin, process::Command};
 use clap::Parser;
+use std::{net, pin::pin, process::Command};
 
 use anyhow::Error;
 
@@ -29,7 +29,8 @@ async fn main() -> Result<(), Error> {
         &peers,
         args.nproc,
     )
-    .await;
+    .await
+    .unwrap();
 
     let hostnames = peers.hostnames().collect::<Vec<_>>();
     let hostname_refs = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Error> {
     let args = Cli::parse();
     let namespace = c"foo";
 
-    let peers = KubernetesPeers::new().await;
+    let peers = KubernetesPeers::new().await?;
     let fence = NetFence::new(
         net::SocketAddr::new("0.0.0.0".parse().unwrap(), PORT),
         &peers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,10 @@ async fn main() -> Result<(), Error> {
     let run = pin!(s.run());
     let rcs = clients
         .iter()
-        .map(async |c| {
+        .map(async |c| -> Result<_, Error> {
+            let envs = c.envs()?;
             let mut cmd = Command::new(&args.command);
-            cmd.envs(&c.envs().unwrap())
-                .args(&args.args)
-                .spawn()?
-                .wait()
-                .await
+            Ok(cmd.envs(&envs).args(&args.args).spawn()?.wait().await?)
         })
         .collect::<FuturesUnordered<_>>()
         .try_collect::<Vec<_>>();

--- a/src/modex.rs
+++ b/src/modex.rs
@@ -131,6 +131,8 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
         };
         let acc = Box::new(self.request_data(proc).await?);
         let data = u8_to_char(&acc);
+
+        // TODO: Create ModexCallback wrapper that handles this.
         // SAFETY: `data` lives as long as `acc`, which is freed by libpmix using `release_vec_u8`.
         unsafe {
             cbfunc(

--- a/src/modex.rs
+++ b/src/modex.rs
@@ -23,7 +23,8 @@ unsafe extern "C" fn response(
     assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
     // SAFETY: Data is owned by PMIx and free'd after this function, so we must
     // copy before returning.
-    let data = unsafe { slice_from_raw_parts(data, sz) }.to_vec();
+    let data = unsafe { slice_from_raw_parts(data, sz) };
+    let data = char_to_u8(data).to_vec();
 
     // SAFETY: We created `cbdata`` in `NetModex::respond`, from `oneshot::Sender<Vec<u8>>`
     let tx = *unsafe { Box::from_raw(cbdata as *mut oneshot::Sender<Vec<u8>>) };

--- a/src/modex.rs
+++ b/src/modex.rs
@@ -46,14 +46,14 @@ pub struct NetModex<'a, D: PeerDiscovery> {
 }
 
 impl<'a, D: PeerDiscovery> NetModex<'a, D> {
-    pub async fn new(addr: SocketAddr, discovery: &'a D, nproc: u16) -> Self {
-        let listener = net::TcpListener::bind(addr).await.unwrap();
-        Self {
+    pub async fn new(addr: SocketAddr, discovery: &'a D, nproc: u16) -> io::Result<Self> {
+        let listener = net::TcpListener::bind(addr).await?;
+        Ok(Self {
             listener,
             discovery,
             nproc,
             request_fn: sys::PMIx_server_dmodex_request,
-        }
+        })
     }
 
     #[cfg(test)]
@@ -62,35 +62,40 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
         discovery: &'a D,
         nproc: u16,
         request_fn: RequestFn,
-    ) -> Self {
-        let listener = net::TcpListener::bind(addr).await.unwrap();
-        Self {
+    ) -> io::Result<Self> {
+        let listener = net::TcpListener::bind(addr).await?;
+        Ok(Self {
             listener,
             discovery,
             nproc,
             request_fn,
-        }
+        })
     }
 
     pub fn addr(&self) -> SocketAddr {
+        // We know we have bound a local socket, so this can be unwrapped.
+        #[allow(clippy::unwrap_used)]
         self.listener.local_addr().unwrap()
     }
 
     fn serialize_proc(proc: sys::pmix_proc_t) -> Vec<u8> {
         let mut s = Vec::with_capacity(mem::size_of::<sys::pmix_proc_t>());
-        s.extend_from_slice(&char_to_u8(&proc.nspace));
+        s.extend_from_slice(char_to_u8(&proc.nspace));
         s.extend_from_slice(&proc.rank.to_be_bytes());
         s
     }
 
     fn parse_proc(buf: [u8; mem::size_of::<sys::pmix_proc_t>()]) -> sys::pmix_proc_t {
         let (nspace, rank) = buf.split_at(mem::size_of::<sys::pmix_nspace_t>());
+        // We have statically known sizes for everything, so can unwrap here.
+        #[allow(clippy::unwrap_used)]
         let rank = u32::from_be_bytes(rank.try_into().unwrap());
+        #[allow(clippy::unwrap_used)]
         let nspace = u8_to_char(nspace).try_into().unwrap();
         sys::pmix_proc_t { rank, nspace }
     }
 
-    async fn request_data(&self, proc: sys::pmix_proc_t) -> Vec<u8> {
+    async fn request_data(&self, proc: sys::pmix_proc_t) -> io::Result<Vec<u8>> {
         assert!(proc.rank <= sys::PMIX_RANK_VALID);
         let req = Self::serialize_proc(proc);
 
@@ -104,20 +109,24 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
                     // TODO: Proper backoff
                     time::sleep(Duration::from_millis(250)).await
                 }
-                Err(e) => panic!("unexpected send error: {e}"),
+                Err(e) => return Err(e),
             }
         };
-        s.write_all(&req).await.unwrap();
+        s.write_all(&req).await?;
         let mut data = Vec::new();
-        s.read_to_end(&mut data).await.unwrap();
-        data
+        s.read_to_end(&mut data).await?;
+        Ok(data)
     }
 
-    pub async fn request(&self, proc: sys::pmix_proc_t, callback: globals::ModexCallback) {
+    pub async fn request(
+        &self,
+        proc: sys::pmix_proc_t,
+        callback: globals::ModexCallback,
+    ) -> io::Result<()> {
         let (Some(cbfunc), cbdata) = callback else {
-            return;
+            return Ok(());
         };
-        let acc = Box::new(self.request_data(proc).await);
+        let acc = Box::new(self.request_data(proc).await?);
         let data = u8_to_char(&acc);
         unsafe {
             cbfunc(
@@ -128,12 +137,13 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
                 Some(globals::release_vec_u8),
                 Box::into_raw(acc) as *mut ffi::c_void,
             )
-        }
+        };
+        Ok(())
     }
 
-    async fn respond(&self, mut c: net::TcpStream) {
+    async fn respond(&self, mut c: net::TcpStream) -> io::Result<()> {
         let mut buf = [0; _];
-        c.read_exact(&mut buf).await.unwrap();
+        c.read_exact(&mut buf).await?;
         let (tx, rx) = oneshot::channel::<Vec<u8>>();
         let proc = Self::parse_proc(buf);
         let tx = Box::new(tx);
@@ -144,17 +154,21 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
         assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
 
         let data = rx.await.unwrap();
-        c.write_all(&data).await.unwrap()
+        c.write_all(&data).await?;
+        Ok(())
     }
 
-    pub async fn serve(&self) {
+    pub async fn serve(&self) -> io::Result<()> {
         while let Ok((c, _)) = self.listener.accept().await {
             // TODO: Process incoming requests in parallel
-            self.respond(c).await
+            self.respond(c).await?
         }
+        Ok(())
     }
 }
 
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
 #[cfg(test)]
 mod test {
     use crate::peer::DirectoryPeers;
@@ -175,7 +189,10 @@ mod test {
 
         let mut data: [ffi::c_char; _] = [1, 2, 3];
         let status = sys::PMIX_SUCCESS as sys::pmix_status_t;
-        unsafe { cbfunc(status, data.as_mut_ptr(), data.len(), cbdata) };
+        #[allow(clippy::undocumented_unsafe_blocks)]
+        unsafe {
+            cbfunc(status, data.as_mut_ptr(), data.len(), cbdata)
+        };
         sys::PMIX_SUCCESS as sys::pmix_status_t
     }
 
@@ -186,19 +203,21 @@ mod test {
         let tmpdir = TempDir::new("modex-test").unwrap();
         let discovery = DirectoryPeers::new(tmpdir.path(), 2);
         let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0);
-        let sender = NetModex::new(addr, &discovery, nproc).await;
-        let responder = NetModex::with_mock_request(addr, &discovery, nproc, request_fn).await;
+        let sender = NetModex::new(addr, &discovery, nproc).await.unwrap();
+        let responder = NetModex::with_mock_request(addr, &discovery, nproc, request_fn)
+            .await
+            .unwrap();
         discovery.register(&sender.addr());
         discovery.register(&responder.addr());
 
         let proc = sys::pmix_proc_t {
             nspace: [0; _],
-            rank: nproc as u32 * 1,
+            rank: nproc as u32,
         };
         let req = pin!(sender.request_data(proc));
         let serve = pin!(responder.serve());
         let resp = select(req, serve).await;
-        let Either::Left((data, _)) = resp else {
+        let Either::Left((Ok(data), _)) = resp else {
             panic!("expected response");
         };
         assert_eq!(data, vec![1, 2, 3]);

--- a/src/modex.rs
+++ b/src/modex.rs
@@ -174,12 +174,12 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
         Ok(())
     }
 
-    pub async fn serve(&self) -> Result<(), ModexError<D::Error>> {
-        while let Ok((c, _)) = self.listener.accept().await {
+    pub async fn serve(&self) -> Result<!, ModexError<D::Error>> {
+        loop {
             // TODO: Process incoming requests in parallel
+            let (c, _) = self.listener.accept().await?;
             self.respond(c).await?
         }
-        Ok(())
     }
 }
 

--- a/src/modex.rs
+++ b/src/modex.rs
@@ -1,5 +1,5 @@
 use core::ffi;
-use std::{io, mem, net::SocketAddr, slice, time::Duration};
+use std::{convert::Infallible, io, mem, net::SocketAddr, slice, time::Duration};
 
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -174,7 +174,7 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
         Ok(())
     }
 
-    pub async fn serve(&self) -> Result<!, ModexError<D::Error>> {
+    pub async fn serve(&self) -> Result<Infallible, ModexError<D::Error>> {
         loop {
             // TODO: Process incoming requests in parallel
             let (c, _) = self.listener.accept().await?;

--- a/src/modex.rs
+++ b/src/modex.rs
@@ -167,8 +167,7 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
     }
 }
 
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::panic)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 #[cfg(test)]
 mod test {
     use crate::peer::DirectoryPeers;
@@ -207,8 +206,8 @@ mod test {
         let responder = NetModex::with_mock_request(addr, &discovery, nproc, request_fn)
             .await
             .unwrap();
-        discovery.register(&sender.addr());
-        discovery.register(&responder.addr());
+        discovery.register(&sender.addr()).unwrap();
+        discovery.register(&responder.addr()).unwrap();
 
         let proc = sys::pmix_proc_t {
             nspace: [0; _],

--- a/src/modex.rs
+++ b/src/modex.rs
@@ -73,8 +73,7 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
     }
 
     pub fn addr(&self) -> SocketAddr {
-        // We know we have bound a local socket, so this can be unwrapped.
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used, reason = "We know we have a socket bound")]
         self.listener.local_addr().unwrap()
     }
 
@@ -87,10 +86,9 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
 
     fn parse_proc(buf: [u8; mem::size_of::<sys::pmix_proc_t>()]) -> sys::pmix_proc_t {
         let (nspace, rank) = buf.split_at(mem::size_of::<sys::pmix_nspace_t>());
-        // We have statically known sizes for everything, so can unwrap here.
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used, reason = "Sizes are statically known")]
         let rank = u32::from_be_bytes(rank.try_into().unwrap());
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used, reason = "Sizes are statically known")]
         let nspace = u8_to_char(nspace).try_into().unwrap();
         sys::pmix_proc_t { rank, nspace }
     }
@@ -167,9 +165,9 @@ impl<'a, D: PeerDiscovery> NetModex<'a, D> {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::panic)]
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used, clippy::panic, clippy::undocumented_unsafe_blocks)]
     use crate::peer::DirectoryPeers;
     use std::{net::Ipv4Addr, pin::pin};
 
@@ -188,10 +186,7 @@ mod test {
 
         let mut data: [ffi::c_char; _] = [1, 2, 3];
         let status = sys::PMIX_SUCCESS as sys::pmix_status_t;
-        #[allow(clippy::undocumented_unsafe_blocks)]
-        unsafe {
-            cbfunc(status, data.as_mut_ptr(), data.len(), cbdata)
-        };
+        unsafe { cbfunc(status, data.as_mut_ptr(), data.len(), cbdata) };
         sys::PMIX_SUCCESS as sys::pmix_status_t
     }
 

--- a/src/peer/dir.rs
+++ b/src/peer/dir.rs
@@ -18,6 +18,8 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error("unable to watch for new peers")]
     Notify(#[from] notify::Error),
+    #[error("unable to parse data")]
+    InvalidAddr(#[from] net::AddrParseError),
 }
 
 pub struct DirectoryPeers<'a> {
@@ -36,7 +38,7 @@ impl<'a> DirectoryPeers<'a> {
     }
 
     fn read_peer(path: &Path) -> Result<net::SocketAddr, Error> {
-        Ok(fs::read_to_string(path)?.parse().unwrap())
+        Ok(fs::read_to_string(path)?.parse()?)
     }
 
     async fn wait_for_peer(&self, path: &Path) -> Result<net::SocketAddr, Error> {

--- a/src/peer/dir.rs
+++ b/src/peer/dir.rs
@@ -108,9 +108,9 @@ impl<'a> PeerDiscovery for DirectoryPeers<'a> {
     }
 }
 
-#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
     use std::collections::HashSet;
 
     use super::*;

--- a/src/peer/k8s.rs
+++ b/src/peer/k8s.rs
@@ -20,34 +20,50 @@ const RANK_LABEL: &str = "batch.kubernetes.io/job-completion-index";
 pub const PORT: u16 = 5000;
 
 #[derive(Error, Debug)]
-pub enum Error {}
+pub enum Error {
+    #[error("unable to detect Kubernetes configuration")]
+    KubernetesConfig(#[from] kube::config::InferConfigError),
+    #[error("error performing Kubernetes operation")]
+    KubernetesApi(#[from] kube::Error),
+    #[error("error watching Kubernetes resources")]
+    KubernetesWatch(#[from] watcher::Error),
+    #[error("required environment variable not defined")]
+    MissingEnv(#[from] env::VarError),
+    #[error("required environment variable could not be parsed")]
+    InvalidEnv(#[from] std::num::ParseIntError),
+    #[error("missing expected field on Kubernetes object")]
+    MissingField(&'static str),
+}
 
 impl KubernetesPeers {
-    pub async fn new() -> Self {
-        let job_name = env::var("JOB_NAME").unwrap();
-        let node_rank = env::var("JOB_COMPLETION_INDEX").unwrap().parse().unwrap();
-        let config = Config::infer().await.unwrap();
+    pub async fn new() -> Result<Self, Error> {
+        let job_name = env::var("JOB_NAME")?;
+        let node_rank = env::var("JOB_COMPLETION_INDEX")?.parse()?;
+        let config = kube::Config::infer().await?;
         Self::new_with_config(job_name, node_rank, config).await
     }
 
-    async fn new_with_config(job_name: String, node_rank: u32, config: Config) -> Self {
-        let client = Client::try_from(config).unwrap();
+    async fn new_with_config(
+        job_name: String,
+        node_rank: u32,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let client = Client::try_from(config)?;
         let pods = Api::<Pod>::default_namespaced(client.clone());
         let jobs = Api::<Job>::default_namespaced(client);
         let nnodes = jobs
             .get(&job_name)
-            .await
-            .unwrap()
+            .await?
             .spec
             .and_then(|s| s.parallelism)
-            .unwrap() as u32;
+            .ok_or(Error::MissingField("Job:spec.parallelism"))? as u32;
 
-        Self {
+        Ok(Self {
             pods,
             job_name,
             nnodes,
             node_rank,
-        }
+        })
     }
 
     fn label_selector(&self, node_rank: Option<u32>) -> String {
@@ -90,7 +106,7 @@ impl PeerDiscovery for KubernetesPeers {
 
     async fn peer(&self, node_rank: u32) -> Result<net::SocketAddr, Self::Error> {
         let mut pod_ips = pin!(self.watch_pods(Some(node_rank)));
-        let pod_ip = pod_ips.next().await.unwrap().unwrap();
+        let pod_ip = pod_ips.next().await.unwrap()?;
         // FIXME: Hack - adding +1 here because this method is used by modex, and peers() is used by fences
         Ok(net::SocketAddr::new(pod_ip.1, PORT + 1))
     }
@@ -99,7 +115,7 @@ impl PeerDiscovery for KubernetesPeers {
         let mut peers = HashMap::new();
         let mut pod_ips = pin!(self.watch_pods(None));
         while peers.len() < self.nnodes as usize {
-            let (rank, pod_ip) = pod_ips.next().await.unwrap().unwrap();
+            let (rank, pod_ip) = pod_ips.next().await.unwrap()?;
             peers.insert(rank, net::SocketAddr::new(pod_ip, PORT));
         }
         Ok(peers)
@@ -110,7 +126,9 @@ impl PeerDiscovery for KubernetesPeers {
     }
 
     fn hostnames(&self) -> impl Iterator<Item = ffi::CString> {
-        (0..self.nnodes)
-            .map(|rank| ffi::CString::new(format!("{}-{}", self.job_name, rank)).unwrap())
+        (0..self.nnodes).map(|rank| {
+            #[allow(clippy::unwrap_used, reason = "Literal string without NULLs")]
+            ffi::CString::new(format!("{}-{}", self.job_name, rank)).unwrap()
+        })
     }
 }

--- a/src/peer/k8s.rs
+++ b/src/peer/k8s.rs
@@ -106,6 +106,10 @@ impl PeerDiscovery for KubernetesPeers {
 
     async fn peer(&self, node_rank: u32) -> Result<net::SocketAddr, Self::Error> {
         let mut pod_ips = pin!(self.watch_pods(Some(node_rank)));
+        #[allow(
+            clippy::unwrap_used,
+            reason = "watcher streams automatically recover from errors"
+        )]
         let pod_ip = pod_ips.next().await.unwrap()?;
         // FIXME: Hack - adding +1 here because this method is used by modex, and peers() is used by fences
         Ok(net::SocketAddr::new(pod_ip.1, PORT + 1))
@@ -115,6 +119,10 @@ impl PeerDiscovery for KubernetesPeers {
         let mut peers = HashMap::new();
         let mut pod_ips = pin!(self.watch_pods(None));
         while peers.len() < self.nnodes as usize {
+            #[allow(
+                clippy::unwrap_used,
+                reason = "watcher streams automatically recover from errors"
+            )]
             let (rank, pod_ip) = pod_ips.next().await.unwrap()?;
             peers.insert(rank, net::SocketAddr::new(pod_ip, PORT));
         }

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ffi, net};
+use std::{collections::HashMap, error::Error, ffi, net};
 
 #[cfg(feature = "test-bins")]
 mod dir;
@@ -9,8 +9,11 @@ pub use dir::DirectoryPeers;
 pub use k8s::KubernetesPeers;
 
 pub trait PeerDiscovery {
-    async fn peer(&self, node_rank: u32) -> net::SocketAddr;
-    async fn peers(&self) -> HashMap<u32, net::SocketAddr>;
+    type Error: Error;
+
+    async fn peer(&self, node_rank: u32) -> Result<net::SocketAddr, Self::Error>;
+    async fn peers(&self) -> Result<HashMap<u32, net::SocketAddr>, Self::Error>;
+
     fn local_ranks(&self, nproc: u16) -> impl Iterator<Item = u32>;
     fn hostnames(&self) -> impl Iterator<Item = ffi::CString>;
 }

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -8,7 +8,6 @@ pub mod k8s;
 pub use dir::DirectoryPeers;
 pub use k8s::KubernetesPeers;
 
-#[allow(async_fn_in_trait)]
 pub trait PeerDiscovery {
     async fn peer(&self, node_rank: u32) -> net::SocketAddr;
     async fn peers(&self) -> HashMap<u32, net::SocketAddr>;

--- a/src/pmix/client.rs
+++ b/src/pmix/client.rs
@@ -54,14 +54,16 @@ impl Client {
     pub fn namespace(&self) -> &CStr {
         let namespace = super::char_to_u8(&self.proc.nspace);
 
-        // PMIx initializes the namespace, so it is guaranteed to be valid
-        #[allow(clippy::unwrap_used)]
+        #[allow(
+            clippy::unwrap_used,
+            reason = "Namespace is initialized by PMIx as a C string"
+        )]
         CStr::from_bytes_until_nul(namespace).unwrap()
     }
 
     fn get(
         proc: Option<&sys::pmix_proc_t>,
-        #[allow(unused_mut)] mut infos: Vec<sys::pmix_info_t>,
+        infos: Vec<sys::pmix_info_t>,
         key: &CStr,
     ) -> sys::pmix_value_t {
         // We should use PMIX_GET_STATIC_VALUES, but this does not work. See

--- a/src/pmix/client.rs
+++ b/src/pmix/client.rs
@@ -3,6 +3,7 @@ use std::{ffi::CStr, mem::MaybeUninit, ptr};
 
 use super::globals;
 use super::sys;
+use super::value::{PmixError, PmixStatus};
 
 pub struct Client {
     proc: sys::pmix_proc_t,
@@ -21,24 +22,25 @@ pub struct Job(sys::pmix_nspace_t, Option<Session>);
 pub struct Proc(u32, Option<Job>);
 
 impl Client {
-    pub fn init(infos: &[sys::pmix_info_t]) -> Result<Client, globals::AlreadyInitialized> {
+    pub fn init(infos: &[sys::pmix_info_t]) -> Result<Client, globals::InitError> {
+        #[allow(clippy::unwrap_used, reason = "no asserts poison the global state")]
         let mut guard = globals::PMIX_STATE.write().unwrap();
+
         if guard.is_some() {
-            return Err(globals::AlreadyInitialized());
+            Err(globals::InitError::AlreadyInitialized)?;
         }
 
         let mut proc = MaybeUninit::<sys::pmix_proc_t>::uninit();
         // SAFETY: `PMIx_init` can be called multiple times, as long as there
         // are matching calls to `PMIx_Finalize`.
-        let status = unsafe {
+        PmixStatus(unsafe {
             sys::PMIx_Init(
                 proc.as_mut_ptr(),
                 infos.as_ptr() as *mut sys::pmix_info_t,
                 infos.len(),
             )
-        };
-        // FIXME: Don't poison the mutex on init error
-        assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
+        })
+        .check()?;
         // SAFETY: `proc` is initialized by `PMIx_Init`
         let proc = unsafe { proc.assume_init() };
         *guard = Some(globals::State::Client);
@@ -67,14 +69,14 @@ impl Client {
         proc: Option<&sys::pmix_proc_t>,
         infos: Vec<sys::pmix_info_t>,
         key: &CStr,
-    ) -> sys::pmix_value_t {
+    ) -> Result<sys::pmix_value_t, PmixError> {
         // We should use PMIX_GET_STATIC_VALUES, but this does not work. See
         // github.com/openpmix/openpmix#3782. Once this is resolved, the dance
         // to free `val_p` below is no longer necessary.
         let mut val_p = MaybeUninit::<*mut sys::pmix_value_t>::uninit();
 
         // SAFETY: `key` is a valid C string, `val` is a single-element pointer.
-        let status = unsafe {
+        PmixStatus(unsafe {
             sys::PMIx_Get(
                 proc.map_or(ptr::null(), |p| p),
                 key.as_ptr(),
@@ -82,8 +84,8 @@ impl Client {
                 infos.len(),
                 val_p.as_mut_ptr(),
             )
-        };
-        assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
+        })
+        .check()?;
 
         // SAFETY: `val_p` is initialized by the call to PMIx_Get above. We now
         // own the pointed-to data, so it is free'd with `PMIx_Value_free`.
@@ -96,11 +98,15 @@ impl Client {
 
             (*val_p).type_ = sys::PMIX_UNDEF as u16;
             sys::PMIx_Value_free(val_p, 1);
-            val
+            Ok(val)
         }
     }
 
-    pub fn get_session(&self, session: Option<Session>, key: &CStr) -> sys::pmix_value_t {
+    pub fn get_session(
+        &self,
+        session: Option<Session>,
+        key: &CStr,
+    ) -> Result<sys::pmix_value_t, PmixError> {
         let mut infos = Vec::with_capacity(3);
         infos.push((sys::PMIX_SESSION_INFO, true).into());
         if let Some(Session(id)) = session {
@@ -110,7 +116,7 @@ impl Client {
         Self::get(None, infos, key)
     }
 
-    pub fn get_job(&self, job: Option<Job>, key: &CStr) -> sys::pmix_value_t {
+    pub fn get_job(&self, job: Option<Job>, key: &CStr) -> Result<sys::pmix_value_t, PmixError> {
         let mut infos = Vec::with_capacity(3);
         infos.push((sys::PMIX_JOB_INFO, true).into());
         if let Some(Job(_, Some(Session(id)))) = job {
@@ -125,7 +131,7 @@ impl Client {
         Self::get(Some(&proc), infos, key)
     }
 
-    pub fn get_proc(&self, proc: Option<Proc>, key: &CStr) -> sys::pmix_value_t {
+    pub fn get_proc(&self, proc: Option<Proc>, key: &CStr) -> Result<sys::pmix_value_t, PmixError> {
         let mut infos = Vec::with_capacity(2);
         if let Some(Proc(_, Some(Job(_, Some(Session(id)))))) = proc {
             infos.push((sys::PMIX_SESSION_ID, id).into())
@@ -145,5 +151,9 @@ impl Drop for Client {
         // SAFETY: PMIx_Finalize must match a call to PMIx_Init.
         let status = unsafe { sys::PMIx_Finalize(ptr::null(), 0) };
         assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
+
+        #[allow(clippy::unwrap_used, reason = "no asserts poison the global state")]
+        let mut guard = globals::PMIX_STATE.write().unwrap();
+        drop(guard.take());
     }
 }

--- a/src/pmix/client.rs
+++ b/src/pmix/client.rs
@@ -37,6 +37,7 @@ impl Client {
         };
         // FIXME: Don't poison the mutes on init error
         assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
+        // SAFETY: `proc` is initialized by `PMIx_Init`
         let proc = unsafe { proc.assume_init() };
         *guard = Some(globals::State::Client);
 
@@ -51,11 +52,10 @@ impl Client {
     }
 
     pub fn namespace(&self) -> &CStr {
-        let namespace = self.proc.nspace;
-        let namespace =
-            unsafe { std::slice::from_raw_parts(namespace.as_ptr() as *const u8, namespace.len()) };
+        let namespace = super::char_to_u8(&self.proc.nspace);
 
         // PMIx initializes the namespace, so it is guaranteed to be valid
+        #[allow(clippy::unwrap_used)]
         CStr::from_bytes_until_nul(namespace).unwrap()
     }
 

--- a/src/pmix/env.rs
+++ b/src/pmix/env.rs
@@ -26,8 +26,8 @@ impl EnvVars {
         for var in vars {
             assert!(var.to_bytes().contains(&b'='));
             // SAFETY: `ptr` may be null, or an existing `argv`-style array. It
-            // is created as `NULL` above, and only modified here. `var` must be
-            // a null-terminated `char*`. Enforced by `ffi::CString`.
+            // is created as `NULL` above, and only modified here. `var` is a
+            // valid C string.
             let status = unsafe { sys::PMIx_Argv_append_nosize(&mut ptr, var.as_ptr()) };
             assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
         }

--- a/src/pmix/env.rs
+++ b/src/pmix/env.rs
@@ -79,8 +79,10 @@ impl<'a> Iterator for EnvIter<'a> {
             // assume they are valid C strings), or from `ffi::CString` in
             // `EnvVars::new()`.
             let env_var = unsafe { ffi::CStr::from_ptr(env_var) }.to_bytes();
-            // Env vars populated by libpmix always contain '='
-            #[allow(clippy::unwrap_used)]
+            #[allow(
+                clippy::unwrap_used,
+                reason = "Env vars populated by libpmix always contain '='"
+            )]
             let split = env_var.iter().position(|c| *c == b'=').unwrap();
             let k = ffi::OsStr::from_bytes(&env_var[..split]);
             let v = ffi::OsStr::from_bytes(&env_var[split + 1..]);
@@ -89,9 +91,9 @@ impl<'a> Iterator for EnvIter<'a> {
     }
 }
 
-#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/src/pmix/env.rs
+++ b/src/pmix/env.rs
@@ -1,9 +1,4 @@
-use std::{
-    ffi,
-    fmt::Debug,
-    marker::PhantomData,
-    os::unix::ffi::OsStrExt,
-};
+use std::{ffi, fmt::Debug, marker::PhantomData, os::unix::ffi::OsStrExt};
 
 #[cfg(test)]
 use std::ptr;
@@ -13,6 +8,10 @@ use super::sys;
 pub struct EnvVars(*mut *mut ffi::c_char);
 
 impl EnvVars {
+    /// # Safety
+    ///
+    /// `ptr` must be an `argv`-style array of `char*`, terminated by a `NULL`
+    /// pointer.
     pub unsafe fn from_ptr(ptr: *mut *mut ffi::c_char) -> Self {
         Self(ptr)
     }
@@ -26,6 +25,9 @@ impl EnvVars {
         let mut ptr = ptr::null_mut();
         for var in vars {
             assert!(var.to_bytes().contains(&b'='));
+            // SAFETY: `ptr` may be null, or an existing `argv`-style array. It
+            // is created as `NULL` above, and only modified here. `var` must be
+            // a null-terminated `char*`. Enforced by `ffi::CString`.
             let status = unsafe { sys::PMIx_Argv_append_nosize(&mut ptr, var.as_ptr()) };
             assert_eq!(status, sys::PMIX_SUCCESS as sys::pmix_status_t);
         }
@@ -39,10 +41,12 @@ impl Debug for EnvVars {
     }
 }
 
+// SAFETY: EnvVars only contains pointers to text, which can safely be moved.
 unsafe impl Send for EnvVars {}
 
 impl Drop for EnvVars {
     fn drop(&mut self) {
+        // SAFETY: This is the destructor for `argv`-style arrays.
         unsafe { sys::PMIx_Argv_free(self.0) }
     }
 }
@@ -63,13 +67,20 @@ impl<'a> Iterator for EnvIter<'a> {
     type Item = (&'a ffi::OsStr, &'a ffi::OsStr);
 
     fn next(&mut self) -> Option<Self::Item> {
+        // SAFETY: We checked on the previous iteration, that this is in-bounds.
         let env_var = unsafe { *self.0 };
-        self.0 = unsafe { self.0.add(1) };
         if env_var.is_null() {
             None
         } else {
+            // SAFETY: The current value is not `NULL``, so the array must
+            // contain at least one more element.
+            self.0 = unsafe { self.0.add(1) };
+            // SAFETY: env vars are either provided by libpmix (in which case we
+            // assume they are valid C strings), or from `ffi::CString` in
+            // `EnvVars::new()`.
             let env_var = unsafe { ffi::CStr::from_ptr(env_var) }.to_bytes();
             // Env vars populated by libpmix always contain '='
+            #[allow(clippy::unwrap_used)]
             let split = env_var.iter().position(|c| *c == b'=').unwrap();
             let k = ffi::OsStr::from_bytes(&env_var[..split]);
             let v = ffi::OsStr::from_bytes(&env_var[split + 1..]);

--- a/src/pmix/env.rs
+++ b/src/pmix/env.rs
@@ -89,6 +89,7 @@ impl<'a> Iterator for EnvIter<'a> {
     }
 }
 
+#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/pmix/globals.rs
+++ b/src/pmix/globals.rs
@@ -2,7 +2,7 @@ use std::{ffi, marker::PhantomData, slice, sync::RwLock};
 use thiserror::Error;
 use tokio::sync::mpsc;
 
-use super::sys;
+use super::{sys, slice_from_raw_parts};
 
 pub type ModexCallback = (sys::pmix_modex_cbfunc_t, *mut ffi::c_void);
 pub type CData = (*mut ffi::c_char, usize);
@@ -72,7 +72,8 @@ unsafe extern "C" fn fence_nb(
     cbfunc: sys::pmix_modex_cbfunc_t,
     cbdata: *mut std::ffi::c_void,
 ) -> sys::pmix_status_t {
-    let info = unsafe { std::slice::from_raw_parts(info, ninfo) };
+    // SAFETY: `info` is provided by `libpmix`, and is valid for this function.
+    let info = unsafe { slice_from_raw_parts(info, ninfo) };
     let ninfo_reqd = info
         .iter()
         .filter(|i| {
@@ -111,7 +112,8 @@ unsafe extern "C" fn direct_modex(
     cbfunc: sys::pmix_modex_cbfunc_t,
     cbdata: *mut std::ffi::c_void,
 ) -> sys::pmix_status_t {
-    let info = unsafe { std::slice::from_raw_parts(info, ninfo) };
+    // SAFETY: `info` is provided by `libpmix`, and is valid for this function.
+    let info = unsafe { slice_from_raw_parts(info, ninfo) };
     let ninfo_reqd = info
         .iter()
         .filter(|i| {

--- a/src/pmix/globals.rs
+++ b/src/pmix/globals.rs
@@ -1,7 +1,7 @@
 use std::{ffi, marker::PhantomData, ops::Deref, slice, sync::RwLock};
 use tokio::sync::mpsc;
 
-use crate::pmix::u8_to_char;
+use crate::pmix::{char_to_u8, u8_to_char};
 
 use super::{slice_from_raw_parts, sys, value::PmixError};
 
@@ -58,7 +58,8 @@ impl Deref for CData {
         // SAFETY: We own the data for our own lifetime. `slice_from_raw_parts`
         // handles the NULL check for us, and there are no alignment
         // requirements for `u8`.
-        unsafe { slice_from_raw_parts(self.0, self.1) }
+        let data = unsafe { slice_from_raw_parts(self.0, self.1) };
+        char_to_u8(data)
     }
 }
 

--- a/src/pmix/globals.rs
+++ b/src/pmix/globals.rs
@@ -126,8 +126,9 @@ unsafe extern "C" fn direct_modex(
         // SAFETY: `proc` is passed to us by libpmix, assume it is valid.
         let proc = unsafe { *proc };
         let cb = (cbfunc, cbdata);
-        // mpsc::Sender only fails to send if the receiver is dropped. This only
-        // happens in Server::drop, which also clears PMIX_STATE state.
+        // mpsc::UnboundedSender::send() only fails if the receiver is dropped,
+        // which only happens in Server::drop, which also clears PMIX_STATE.
+        #[allow(clippy::unwrap_used, reason = "Unreachable if receiver is dropped")]
         s.send(Event::DirectModex { proc, cb }).unwrap();
         sys::PMIX_SUCCESS as sys::pmix_status_t
     } else {

--- a/src/pmix/globals.rs
+++ b/src/pmix/globals.rs
@@ -93,9 +93,8 @@ unsafe extern "C" fn fence_nb(
         let cb = (cbfunc, cbdata);
         let data = (data, ndata);
         // mpsc::UnboundedSender::send() only fails if the receiver is dropped,
-        // which only happens in Server::drop, which also clears PMIX_STATE,
-        // making this call unreachable.
-        #[allow(clippy::unwrap_used)]
+        // which only happens in Server::drop, which also clears PMIX_STATE.
+        #[allow(clippy::unwrap_used, reason = "Unreachable if receiver is dropped")]
         s.send(Event::Fence { procs, data, cb }).unwrap();
         sys::PMIX_SUCCESS as sys::pmix_status_t
     } else {

--- a/src/pmix/globals.rs
+++ b/src/pmix/globals.rs
@@ -6,6 +6,7 @@ use super::{slice_from_raw_parts, sys, value::PmixError};
 pub type ModexCallback = (sys::pmix_modex_cbfunc_t, *mut ffi::c_void);
 pub type CData = (*mut ffi::c_char, usize);
 
+#[allow(clippy::large_enum_variant, reason = "pmix_proc_t is large")]
 pub enum Event {
     Fence {
         procs: Vec<sys::pmix_proc_t>,

--- a/src/pmix/mod.rs
+++ b/src/pmix/mod.rs
@@ -33,3 +33,16 @@ pub fn u8_to_char(bytes: &[u8]) -> &[ffi::c_char] {
     // SAFETY: This is the recommended way to transmute [u8] to [ffi::c_char]
     unsafe { slice::from_raw_parts(ptr as *const ffi::c_char, bytes.len()) }
 }
+
+/// # SAFETY
+///
+/// Safety requirements are exactly as for `std::slice::from_raw_parts`, except
+/// `data` may be `NULL`.
+pub unsafe fn slice_from_raw_parts<'a, T>(data: *const T, ndata: usize) -> &'a [T] {
+    if !data.is_null() {
+        // SAFETY: satisfied by this function's safety requirements.
+        unsafe { slice::from_raw_parts(data, ndata) }
+    } else {
+        &[]
+    }
+}

--- a/src/pmix/mod.rs
+++ b/src/pmix/mod.rs
@@ -1,5 +1,6 @@
 use std::{ffi, slice};
 
+#[cfg(feature = "test-bins")]
 pub mod client;
 pub mod env;
 pub mod globals;

--- a/src/pmix/mod.rs
+++ b/src/pmix/mod.rs
@@ -8,20 +8,27 @@ pub mod sys;
 mod value;
 
 pub fn get_version_str() -> &'static ffi::CStr {
+    // SAFETY: PMIx_Get_version returns a statically allocated C string.
     unsafe { ffi::CStr::from_ptr(sys::PMIx_Get_version()) }
 }
 
 pub fn is_initialized() -> bool {
+    // SAFETY: No concerns for PMIx_Initialized.
     let status = unsafe { sys::PMIx_Initialized() };
     status != 0
 }
 
 pub fn char_to_u8(chars: &[ffi::c_char]) -> &[u8] {
     let ptr = chars.as_ptr();
-    unsafe { slice::from_raw_parts(ptr as *const u8, chars.len()) }
+    // SAFETY: This is the recommended way to transmute [ffi::c_char] to [u8]
+    #[allow(clippy::unnecessary_cast)]
+    unsafe {
+        slice::from_raw_parts(ptr as *const u8, chars.len())
+    }
 }
 
 pub fn u8_to_char(bytes: &[u8]) -> &[ffi::c_char] {
     let ptr = bytes.as_ptr();
+    // SAFETY: This is the recommended way to transmute [u8] to [ffi::c_char]
     unsafe { slice::from_raw_parts(ptr as *const ffi::c_char, bytes.len()) }
 }

--- a/src/pmix/mod.rs
+++ b/src/pmix/mod.rs
@@ -21,7 +21,7 @@ pub fn is_initialized() -> bool {
 pub fn char_to_u8(chars: &[ffi::c_char]) -> &[u8] {
     let ptr = chars.as_ptr();
     // SAFETY: This is the recommended way to transmute [ffi::c_char] to [u8]
-    #[allow(clippy::unnecessary_cast)]
+    #[cfg_attr(not(target_arch = "x86_64"), expect(clippy::unnecessary_cast))]
     unsafe {
         slice::from_raw_parts(ptr as *const u8, chars.len())
     }

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -12,7 +12,7 @@ use crate::ModexError;
 
 use super::super::{fence, modex, peer};
 use super::{
-    char_to_u8, env, globals, sys,
+    u8_to_char, env, globals, sys,
     value::{PmixError, PmixStatus, Rank},
 };
 
@@ -113,9 +113,9 @@ impl<'a, D: peer::PeerDiscovery> Namespace<'a, D> {
         hostnames: &[&ffi::CStr],
         nlocalprocs: u16,
     ) -> Result<Self, PmixError> {
-        let namespace = char_to_u8(namespace.to_bytes_with_nul());
+        let namespace = namespace.to_bytes_with_nul();
         let mut nspace: sys::pmix_nspace_t = [0; _];
-        nspace[..namespace.len()].copy_from_slice(namespace);
+        nspace[..namespace.len()].copy_from_slice(u8_to_char(namespace));
 
         let nnodes = hostnames.len() as u32;
 

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -123,7 +123,7 @@ impl<'a, D: peer::PeerDiscovery> Namespace<'a, D> {
                     let rank = Rank((nlocalprocs as u32 * node_rank) + i as u32);
                     [
                         (sys::PMIX_RANK, rank).into(),
-                        (sys::PMIX_LOCAL_RANK, i as u16).into(),
+                        (sys::PMIX_LOCAL_RANK, i).into(),
                         (sys::PMIX_NODEID, node_rank).into(),
                     ]
                 })
@@ -187,7 +187,7 @@ impl<'a, D: peer::PeerDiscovery> Client<'a, D> {
                 ptr::null_mut(),
             )
         };
-        assert_eq!(status, sys::PMIX_OPERATION_SUCCEEDED as i32);
+        assert_eq!(status, sys::PMIX_OPERATION_SUCCEEDED as sys::pmix_status_t);
         Client {
             proc,
             namespace: PhantomData,
@@ -210,6 +210,7 @@ impl<'a, D: peer::PeerDiscovery> Drop for Client<'a, D> {
     }
 }
 
+#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
     use std::net;

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -1,5 +1,6 @@
 use futures::future::select;
 use std::cell::RefCell;
+use std::convert::Infallible;
 use std::ffi;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -56,7 +57,7 @@ impl<'a, D: peer::PeerDiscovery> Server<'a, D> {
         })
     }
 
-    async fn handle_events(&self) -> Result<!, ModexError<D::Error>> {
+    async fn handle_events(&self) -> Result<Infallible, ModexError<D::Error>> {
         loop {
             match self.rx.borrow_mut().recv().await.unwrap() {
                 globals::Event::Fence { procs, data, cb } => {
@@ -67,7 +68,7 @@ impl<'a, D: peer::PeerDiscovery> Server<'a, D> {
         }
     }
 
-    pub async fn run(&self) -> Result<!, ModexError<D::Error>> {
+    pub async fn run(&self) -> Result<Infallible, ModexError<D::Error>> {
         let events = pin!(self.handle_events());
         let modex = pin!(self.modex.serve());
         select(events, modex).await.factor_first().0

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -60,7 +60,7 @@ impl<'a, D: peer::PeerDiscovery> Server<'a, D> {
         loop {
             match self.rx.borrow_mut().recv().await.unwrap() {
                 globals::Event::Fence { procs, data, cb } => {
-                    self.fence.submit(&procs, data, cb).await
+                    self.fence.submit(&procs, data, cb).await.unwrap()
                 }
                 globals::Event::DirectModex { proc, cb } => self.modex.request(proc, cb).await,
             }
@@ -232,7 +232,8 @@ mod test {
                 net::SocketAddr::new(net::Ipv4Addr::LOCALHOST.into(), 0),
                 &discovery,
             )
-            .await;
+            .await
+            .unwrap();
             let modex = modex::NetModex::new(
                 net::SocketAddr::new(net::Ipv4Addr::LOCALHOST.into(), 0),
                 &discovery,

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -1,9 +1,9 @@
 use futures::future::select;
 use std::cell::RefCell;
+use std::ffi;
 use std::marker::PhantomData;
 use std::pin::pin;
 use std::ptr;
-use std::{ffi, io};
 use tokio::sync::mpsc;
 
 use tempdir::TempDir;

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -210,9 +210,9 @@ impl<'a, D: peer::PeerDiscovery> Drop for Client<'a, D> {
     }
 }
 
-#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
     use std::net;
 
     use serial_test::serial;

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -56,7 +56,7 @@ impl<'a, D: peer::PeerDiscovery> Server<'a, D> {
         })
     }
 
-    async fn handle_events(&self) -> Result<(), ModexError<D::Error>> {
+    async fn handle_events(&self) -> Result<!, ModexError<D::Error>> {
         loop {
             match self.rx.borrow_mut().recv().await.unwrap() {
                 globals::Event::Fence { procs, data, cb } => {
@@ -67,7 +67,7 @@ impl<'a, D: peer::PeerDiscovery> Server<'a, D> {
         }
     }
 
-    pub async fn run(&self) -> Result<(), ModexError<D::Error>> {
+    pub async fn run(&self) -> Result<!, ModexError<D::Error>> {
         let events = pin!(self.handle_events());
         let modex = pin!(self.modex.serve());
         select(events, modex).await.factor_first().0

--- a/src/pmix/sys.rs
+++ b/src/pmix/sys.rs
@@ -3,5 +3,6 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 #![allow(unnecessary_transmutes)]
+#![allow(clippy::missing_safety_doc)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings_pmix.rs"));

--- a/src/pmix/value.rs
+++ b/src/pmix/value.rs
@@ -1,7 +1,31 @@
 use std::ffi::{CStr, c_void};
+use std::fmt::Display;
 use std::mem::MaybeUninit;
 
 use super::sys;
+
+pub struct PmixStatus(pub sys::pmix_status_t);
+
+const PMIX_SUCCESS: sys::pmix_status_t = sys::PMIX_SUCCESS as sys::pmix_status_t;
+
+impl PmixStatus {
+    pub fn check(&self) -> Result<(), PmixError> {
+        match self.0 {
+            PMIX_SUCCESS => Ok(()),
+            sys::PMIX_OPERATION_SUCCEEDED => Ok(()),
+            e => Err(PmixError(e)),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub struct PmixError(pub sys::pmix_status_t);
+
+impl Display for PmixError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("PmixError({})", self.0))
+    }
+}
 
 impl Drop for sys::pmix_value_t {
     fn drop(&mut self) {

--- a/tests/k8s.rs
+++ b/tests/k8s.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::panic)]
+
 use std::{
     env,
     path::Path,
@@ -33,7 +35,7 @@ fn wait_for_complete(name: &str, timeout: Duration) -> ExitStatus {
     Command::new("kubectl")
         .args(["wait", "--for", "condition=Complete"])
         .arg(format!("--timeout={}s", timeout.as_secs()))
-        .arg(&format!("jobs.batch/{}", name))
+        .arg(format!("jobs.batch/{}", name))
         .status()
         .unwrap()
 }

--- a/tests/mpi.rs
+++ b/tests/mpi.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::panic)]
+
 use std::process::Command;
 
 use tempdir::TempDir;

--- a/tests/pmix.rs
+++ b/tests/pmix.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::panic)]
+
 use std::process::Command;
 
 use tempdir::TempDir;


### PR DESCRIPTION
This is a big chunk of #10, but not a complete fix. All of the `unsafe` and `panic` calls are handled, but there is still a lint about holding a `RefCell` across `await` in `Server::run`.
