### PR TITLE
Split server into shared & mut components

### DIFF
--- a/src/bin/mock/server.rs
+++ b/src/bin/mock/server.rs
@@ -23,10 +23,7 @@ pub struct ServerArgs {
     command: Vec<String>,
 }
 
-fn spawn_client<D: peer::PeerDiscovery>(
-    args: &[String],
-    c: &pmix::server::Client<D>,
-) -> std::process::Child {
+fn spawn_client(args: &[String], c: &pmix::server::Client) -> std::process::Child {
     let mut cmd = Command::new(std::env::current_exe().unwrap());
     cmd.arg("client")
         .args(args)
@@ -69,7 +66,7 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
     peers.register(&modex.addr()).unwrap();
 
     let server_dir = tmpdir.join("server");
-    let s = pmix::server::Server::init(fence, modex, &server_dir).unwrap();
+    let s = pmix::server::Server::init(&server_dir).unwrap();
 
     let hostnames = peers.hostnames().collect::<Vec<_>>();
     let hostnames = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();
@@ -90,7 +87,7 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
             .map(|mut p| p.wait().unwrap())
             .collect::<Vec<_>>()
     });
-    let run = pin!(s.run());
+    let run = pin!(s.run(&fence, &modex));
     let Either::Left((rcs, _)) = select(rcs, run).await else {
         panic!("server stopped unexpectedly")
     };

--- a/src/bin/mock/server.rs
+++ b/src/bin/mock/server.rs
@@ -66,7 +66,7 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
     peers.register(&modex.addr()).unwrap();
 
     let server_dir = tmpdir.join("server");
-    let s = pmix::server::Server::init(&server_dir).unwrap();
+    let (s, mut e) = pmix::server::Server::init(&server_dir).unwrap();
 
     let hostnames = peers.hostnames().collect::<Vec<_>>();
     let hostnames = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();
@@ -87,7 +87,7 @@ pub(crate) async fn run(args: ServerArgs) -> Result<(), Error> {
             .map(|mut p| p.wait().unwrap())
             .collect::<Vec<_>>()
     });
-    let run = pin!(s.run(&fence, &modex));
+    let run = pin!(e.run(&fence, &modex));
     let Either::Left((rcs, _)) = select(rcs, run).await else {
         panic!("server stopped unexpectedly")
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,14 +33,14 @@ async fn main() -> Result<(), Error> {
     let hostname_refs = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();
 
     let tempdir = TempDir::new("pmi-k8s")?;
-    let s = pmix::server::Server::init(tempdir.path())?;
+    let (s, mut e) = pmix::server::Server::init(tempdir.path())?;
     let ns = pmix::server::Namespace::register(&s, namespace, &hostname_refs, args.nproc)?;
     let clients = peers
         .local_ranks(args.nproc)
         .map(|i| pmix::server::Client::register(&ns, i))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let run = pin!(s.run(&fence, &modex));
+    let run = pin!(e.run(&fence, &modex));
     let rcs = clients
         .iter()
         .map(async |c| -> Result<_, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,14 +33,14 @@ async fn main() -> Result<(), Error> {
     let hostname_refs = hostnames.iter().map(|h| h.as_c_str()).collect::<Vec<_>>();
 
     let tempdir = TempDir::new("pmi-k8s")?;
-    let s = pmix::server::Server::init(fence, modex, tempdir.path())?;
+    let s = pmix::server::Server::init(tempdir.path())?;
     let ns = pmix::server::Namespace::register(&s, namespace, &hostname_refs, args.nproc)?;
     let clients = peers
         .local_ranks(args.nproc)
         .map(|i| pmix::server::Client::register(&ns, i))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let run = pin!(s.run());
+    let run = pin!(s.run(&fence, &modex));
     let rcs = clients
         .iter()
         .map(async |c| -> Result<_, Error> {

--- a/src/pmix/client.rs
+++ b/src/pmix/client.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::{ffi::CStr, mem::MaybeUninit, ptr};
 
 use super::globals;
@@ -7,9 +6,6 @@ use super::value::{PmixError, PmixStatus};
 
 pub struct Client {
     proc: sys::pmix_proc_t,
-    // I'm not sure what PMIx functions are thread-safe, so mark the client as
-    // !Sync. Client::init enforces that only one is live at a time.
-    _marker: globals::Unsync,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -45,10 +41,7 @@ impl Client {
         let proc = unsafe { proc.assume_init() };
         *guard = Some(globals::State::Client);
 
-        Ok(Self {
-            proc,
-            _marker: globals::Unsync(PhantomData),
-        })
+        Ok(Self { proc })
     }
 
     pub fn rank(&self) -> u32 {

--- a/src/pmix/globals.rs
+++ b/src/pmix/globals.rs
@@ -1,4 +1,4 @@
-use std::{ffi, marker::PhantomData, ops::Deref, slice, sync::RwLock};
+use std::{ffi, ops::Deref, slice, sync::RwLock};
 use tokio::sync::mpsc;
 
 use crate::pmix::{char_to_u8, u8_to_char};
@@ -98,10 +98,6 @@ pub enum InitError {
     #[error("PMIx global state was already initialized")]
     AlreadyInitialized,
 }
-
-pub struct Unsync(pub PhantomData<*const ()>);
-// SAFETY: This is a marker type, for `Send + !Sync`
-unsafe impl Send for Unsync {}
 
 /// # Safety
 ///

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -52,9 +52,6 @@ impl<'a> ServerEvents<'a> {
 
 pub struct Server<'a> {
     _dir: &'a PhantomData<Path>,
-    // I'm not sure what PMIx functions are thread-safe, so mark the server as
-    // !Sync. Server::init enforces that only one is live at a time.
-    _marker: globals::Unsync,
 }
 
 impl<'a> Server<'a> {
@@ -84,10 +81,7 @@ impl<'a> Server<'a> {
         .check()?;
 
         Ok((
-            Self {
-                _dir: &PhantomData,
-                _marker: globals::Unsync(PhantomData),
-            },
+            Self { _dir: &PhantomData },
             ServerEvents {
                 rx,
                 _server: &PhantomData,

--- a/src/pmix/server.rs
+++ b/src/pmix/server.rs
@@ -58,8 +58,6 @@ impl<'a> Server<'a> {
         })
     }
 
-    // FIXME: We need a fairly large refactor to avoid this lint.
-    #[expect(clippy::await_holding_refcell_ref)]
     async fn handle_events<D: PeerDiscovery>(
         &self,
         fence: &fence::NetFence<'a, D>,


### PR DESCRIPTION
Some misc cleanups, but the main thing is the removal of the lint exception for the `RefCell`. We want to ensure two things:

1. The server (statically) outlives all namespace/client objects created. This is easy with lifetimes/`PhantomData`.
2. That there is only one thread calling `Server::run()` at any point. This would be straightforward by taking a `&mut` reference.

However, (1) and (2) are largely incompatible, because (1) requires that all child objects hold a reference, which means we can't take an `&mut` reference for (2).

By separating out the server object for (1), and the server event processor for (2), we get both (unless I'm missing something very obvious).

Fixes #10.