### PR TITLE
Rename lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     tags: ["v*"]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
So we can add a protection rule that requires it.